### PR TITLE
Move /new path above /:id path. 

### DIFF
--- a/lib/rails/generators/joosy/templates/app/routes.js.coffee
+++ b/lib/rails/generators/joosy/templates/app/routes.js.coffee
@@ -3,6 +3,6 @@ Joosy.Router.map
   '/'             : Welcome.IndexPage
 # '/resources'    :
 #   '/'           : Resource.IndexPage
+#   '/new'        : Resource.NewPage
 #   '/:id'        : Resource.ShowPage
 #   '/:id/edit'   : Resource.EditPage
-#   '/new'        : Resource.EditPage


### PR DESCRIPTION
The official forms guide mentions that URL will match first route possible. In this case Posts.ShowPage will catch http://localhost:3000/blog/new instead of Posts.NewPage.
