### PR TITLE
pass complete json answer as second parameter to find 'all' callback 

### DIFF
--- a/app/assets/javascripts/joosy/core/resource/rest.js.coffee
+++ b/app/assets/javascripts/joosy/core/resource/rest.js.coffee
@@ -205,7 +205,7 @@ class Joosy.Resource.REST extends Joosy.Resource.Generic
 
       @__query @collectionPath(options), 'GET', options.params, (data) =>
         result.load data
-        callback?(result)
+        callback?(result, data)
     else
       result = @build where
       @__query @memberPath(where, options), 'GET', options.params, (data) =>

--- a/spec/javascripts/joosy/core/resource/rest_spec.js.coffee
+++ b/spec/javascripts/joosy/core/resource/rest_spec.js.coffee
@@ -75,12 +75,13 @@ describe "Joosy.Resource.REST", ->
       checkAndRespond @server.requests[0], 'GET', /^\/fluffies\/1\?_=\d+/, rawData
 
   describe "finds collection", ->
-    rawData = '{"fluffies": [{"id": 1, "name": "test1"}, {"id": 2, "name": "test2"}]}'
+    rawData = '{"page": 42, "fluffies": [{"id": 1, "name": "test1"}, {"id": 2, "name": "test2"}]}'
 
-    callback = sinon.spy (target) ->
+    callback = sinon.spy (target, data) ->
       expect(target instanceof Joosy.Resource.RESTCollection).toEqual true
       expect(target.size()).toEqual 2
       expect(target.at(0) instanceof Fluffy).toEqual true
+      expect(data).toEqual JSon.parse(rawData)
 
     it "without params", ->
       resource = Fluffy.find 'all', callback


### PR DESCRIPTION
I'm realizing pagination with Joosy at the moment - so I need to pass some additional information with the JSON answer. In order to reach the complete JSON response in the "find 'all' " callback I needed to add a second parameter, so I can say:

``` javascript
@fetch (complete) ->
  User.find 'all', (users, data) =>
    @data.pagination = {total: data.total, total_pages: data.total_pages, current_page: data.current_page}
    @data.users = users
    complete()
```
