### PR TITLE
form.radioButton generating proper ids like ActiveSupport

### DIFF
--- a/app/assets/javascripts/joosy/core/helpers/form.js.coffee
+++ b/app/assets/javascripts/joosy/core/helpers/form.js.coffee
@@ -24,7 +24,14 @@ Joosy.helpers 'Application', ->
   #
   class Form
     constructor: (@context, @resource, @options) ->
-    label: (method, options={}, content='') -> @context.label(@resource, method, Joosy.Module.merge(extendIds: @options.extendIds, options), content)
+
+    label: (method, options={}, content='') ->
+      if !Object.isObject(options)
+        content = options
+        options = {}
+
+      @context.label(@resource, method, Joosy.Module.merge(extendIds: @options.extendIds, options), content)
+
     radioButton: (method, tagValue, options={}) -> @context.radioButton(@resource, method, tagValue, Joosy.Module.merge(extendIds: @options.extendIds, options))
     textArea: (method, options={}) -> @context.textArea(@resource, method, Joosy.Module.merge(extendIds: @options.extendIds, options))
     checkBox: (method, options={}, checkedValue=1, uncheckedValue=0) -> @context.checkBox(@resource, method, Joosy.Module.merge(extendIds: @options.extendIds, options), checkedValue, uncheckedValue)

--- a/spec/javascripts/joosy/core/helpers/forms_spec.js.coffee
+++ b/spec/javascripts/joosy/core/helpers/forms_spec.js.coffee
@@ -35,6 +35,7 @@ describe "Joosy.Helpers.Form", ->
       expect(h.textField 'a', '[b][c]', {a: 'b'}).toBeTag 'input', '', id: 'a_b_c', name: 'a[b][c]', a: 'b', type: 'text'
 
     it "renders label", ->
+      expect(h.label 'a', 'b', 'test').toBeTag 'label', 'test', for: 'a_b'
       expect(h.label 'a', 'b', {a: 'b'}, 'test').toBeTag 'label', 'test', for: 'a_b', a: 'b'
 
     it "renders checkBox", ->
@@ -80,6 +81,7 @@ describe "Joosy.Helpers.Form", ->
         expect(form["#{type}Field"] 'b', {a: 'b'}).toBeTag 'input', '', id: 'test_b', name: 'test[b]', a: 'b', type: type
 
     it "renders label", ->
+      expect(form.label 'b', 'test').toBeTag 'label', 'test', for: 'test_b'
       expect(form.label 'b', {a: 'b'}, 'test').toBeTag 'label', 'test', for: 'test_b', a: 'b'
 
     it "renders checkBox", ->
@@ -107,6 +109,7 @@ describe "Joosy.Helpers.Form", ->
         expect(form["#{type}Field"] 'b', {a: 'b'}).toBeTag 'input', '', id: 'test_1_b', name: 'test[b]', a: 'b', type: type
 
     it "renders label", ->
+      expect(form.label 'b', 'test').toBeTag 'label', 'test', for: 'test_1_b'
       expect(form.label 'b', {a: 'b'}, 'test').toBeTag 'label', 'test', for: 'test_1_b', a: 'b'
 
     it "renders checkBox", ->


### PR DESCRIPTION
The following code will generate 2 radio inputs with the same id property `#resource_foo`

``` coffee
  == @form_for @resource, (f) ->
    == f.radioButton "foo", "bar"
    == f.radioButton "foo", "baz"
```

This pull request fixes the issue so that inputs have ids of `#resource_foo_bar` and `#resource_foo_baz`, just like in ActiveSupport.
