### PR TITLE
Add reverse url support to Joosy.Router

### DIFF
--- a/app/assets/javascripts/joosy/core/router.js.coffee
+++ b/app/assets/javascripts/joosy/core/router.js.coffee
@@ -37,7 +37,7 @@ Joosy.Router =
   # TODO: Write readme
   #
   __namespace: ""
-  __as_namespace: ""
+  __asNamespace: ""
   
   #
   # Set the restriction pattern. If the requested url does not match this it
@@ -51,6 +51,8 @@ Joosy.Router =
   reset: ->
     @rawRoutes = Object.extended()
     @routes = Object.extended()
+    @__namespace = ""
+    @__asNamespace = ""
     
     
   #
@@ -103,15 +105,19 @@ Joosy.Router =
   # @option options [String] as  name of the route, used for reverse routing
   #
   match: (route, options={}) ->
-    as = @__as_namespace + options["as"]
-    route_name = @__namespace + route
+    if @__asNamespace
+      as = @__asNamespace + options["as"].capitalize()
+    else
+      as = options["as"]
+    
+    routeName = @__namespace + route
 
     map = {}
     map[route] = options["to"]
     
     Joosy.Module.merge @rawRoutes, map
     
-    @__inject_reverse_url(as, route_name)
+    @__injectReverseUrl(as, routeName)
   
   #
   # Shortcut to match "/"
@@ -129,7 +135,7 @@ Joosy.Router =
   #
   # @param options [String] to  function to which the route routes
   #
-  not_found: (options={}) ->
+  notFound: (options={}) ->
     @match(404, to: options["to"])
  
   #
@@ -144,12 +150,12 @@ Joosy.Router =
       block = options
       options = {}
       
-    new_scope = $.extend({}, this)
-    new_scope.rawRoutes = {}
-    new_scope.__namespace += name
-    new_scope.__as_namespace += "#{options["as"]}_" if options["as"]
-    block.call(new_scope) if Object.isFunction(block)
-    @rawRoutes[name] = new_scope.rawRoutes
+    newScope = $.extend({}, this)
+    newScope.rawRoutes = {}
+    newScope.__namespace += name
+    newScope.__asNamespace += "#{options["as"]}" if options["as"]
+    block.call(newScope) if Object.isFunction(block)
+    @rawRoutes[name] = newScope.rawRoutes
     
   #
   # Inits the routing system and loads the current route
@@ -282,7 +288,7 @@ Joosy.Router =
   #                               "/edit": TestPage
   #                        joins to "/projects/:id/edit"
   #
-  __inject_reverse_url: (as, route) ->
+  __injectReverseUrl: (as, route) ->
     return if as == undefined
     
     fnc = (options) ->
@@ -291,10 +297,10 @@ Joosy.Router =
         url = url.replace(str.substr(1), options[str.substr(2)])
       "#!#{url}"
 
-    window["#{as}_path"] = (options) ->
+    Joosy.Helpers.Application["#{as}Path"] = (options) ->
       fnc(options)
       
-    window["#{as}_url"] = (options) ->
+    Joosy.Helpers.Application["#{as}Url"] = (options) ->
       url = 'http://' + window.location.host + window.location.pathname
       "#{url}#{fnc(options)}"
 

--- a/spec/javascripts/joosy/core/router_spec.js.coffee
+++ b/spec/javascripts/joosy/core/router_spec.js.coffee
@@ -154,7 +154,7 @@ describe "Joosy.Router", ->
     Joosy.Router.draw ->
       @root to: spies.root
       @match '/page', to: TestPage
-      @not_found to: spies.wildcard
+      @notFound to: spies.wildcard
       
     expect(Joosy.Router.rawRoutes).toEqual(raw_routes_for_map)
     
@@ -166,7 +166,7 @@ describe "Joosy.Router", ->
         '/page/:id': spies.section
         '/page2/:more': TestPage
       404: spies.wildcard
-    raw_routes_for_map = Joosy.Router.rawRoutes
+    rawRoutesForMap = Joosy.Router.rawRoutes
 
     Joosy.Router.reset()
     
@@ -176,23 +176,25 @@ describe "Joosy.Router", ->
       @namespace '/section', ->
         @match '/page/:id', to: spies.section
         @match '/page2/:more', to: TestPage
-      @not_found to: spies.wildcard
+      @notFound to: spies.wildcard
       
-    expect(Joosy.Router.rawRoutes).toEqual(raw_routes_for_map)
+    expect(Joosy.Router.rawRoutes).toEqual(rawRoutesForMap)
     
   it "should DRAW simple route reverses, only using match and root", ->
     Joosy.Router.draw ->
       @root to: spies.root
       @match '/page', to: TestPage, as: "page"
-      @match '/page/:id', to: TestPage, as: "page_for"
-      @not_found to: spies.wildcard
+      @match '/page/:id', to: TestPage, as: "pageFor"
+      @notFound to: spies.wildcard
       
-    expect(root_url).not.toEqual undefined
-    expect(root_path).not.toEqual undefined
+    validate = ->
+      expect(@rootUrl).not.toEqual undefined
+      expect(@rootPath).not.toEqual undefined
     
-    expect(root_path()).toEqual "#!/"
-    expect(page_path()).toEqual "#!/page"
-    expect(page_for_path(id: 3)).toEqual "#!/page/3"
+      expect(@rootPath()).toEqual "#!/"
+      expect(@pagePath()).toEqual "#!/page"
+      expect(@pageForPath(id: 3)).toEqual "#!/page/3"
+    validate.call(Joosy.Helpers.Application)
     
   it "should DRAW more complex reverses using namespaces", ->
     Joosy.Router.draw ->
@@ -204,25 +206,29 @@ describe "Joosy.Router", ->
           @match "/delete", to: TestPage, as: "delete"
           
       @namespace '/tickets', ->
-        @match "/", to: TestPage, as: "tasks_index"
+        @match "/", to: TestPage, as: "tasksIndex"
         
       @namespace '/activities', ->
         @root to: TestPage, as: "activities"
 
-    expect(projects_index_path).not.toEqual undefined
-    expect(projects_index_path()).not.toEqual "#!/projects"
-    expect(projects_index_path()).toEqual "#!/projects/"
+    validate = ->
+      expect(@projectsIndexPath).not.toEqual undefined
+      expect(@projectsIndexPath()).not.toEqual "#!/projects"
+      expect(@projectsIndexPath()).toEqual "#!/projects/"
     
-    expect(projects_show_path(id: 3)).toEqual "#!/projects/3/"
-    expect(projects_edit_path(id: 3)).toEqual "#!/projects/3/edit"
-    expect(projects_delete_path(id: 3)).toEqual "#!/projects/3/delete"
+      expect(@projectsShowPath(id: 3)).toEqual "#!/projects/3/"
+      expect(@projectsEditPath(id: 3)).toEqual "#!/projects/3/edit"
+      expect(@projectsDeletePath(id: 3)).toEqual "#!/projects/3/delete"
     
-    expect(tasks_index_path()).toEqual "#!/tickets/"
-    expect(activities_path()).toEqual "#!/activities/"
+      expect(@tasksIndexPath()).toEqual "#!/tickets/"
+      expect(@activitiesPath()).toEqual "#!/activities/"
+    validate.call(Joosy.Helpers.Application)
     
   it "should return reverse url with hostname and pathname", ->
     Joosy.Router.draw ->
-      @match "/projects/", to: TestPage, as: "projects_index"
+      @match "/projects/", to: TestPage, as: "projectsIndex"
         
-    expect(projects_index_path()).toEqual "#!/projects/"
-    expect(projects_index_url()).toEqual "http://localhost:8888/#!/projects/"
+    validate = ->
+      expect(@projectsIndexPath()).toEqual "#!/projects/"
+      expect(@projectsIndexUrl()).toEqual "http://localhost:8888/#!/projects/"
+    validate.call(Joosy.Helpers.Application)


### PR DESCRIPTION
Hi,

I've added reverse url support to Joosy.Router. For this, I created a new method named draw, which works similar to one in Ruby on Rails, with a nice DSL. Example code:

``` coffeescript
Joosy.Router.draw ->
  @root to: Dashboard.IndexPage
  @not_found to: -> alert("Not found")

  @match '/activities', to: Activities.IndexPage, as: "activities"
  @match '/feed', to: Feed.FeedPage

  @namespace '/projects', as: "projects", ->
    @match "/", to: Projects.IndexPage, as: "index"
    @namespace "/:id", ->
      @match "/", to: Projects.ShowPage, as: "show"
      @match "/edit", to: Projects.EditPage, as: "edit"
      @match "/delete", to: Projects.DeletePage, as: "delete"

  @namespace '/tickets', ->
    @match "/", to: Tickets.IndexPage, as: "tickets_index"
```

Now it's easy to get reverse url for this:

``` coffeescript
root_path() # #!/
activities_path # #!/activities
projects_index_path # #!/projects/
projects_edit_path(id: 3) # #!/projects/3/edit

root_url() # http://example.com/current/path/#!/
activities_url() # http://example.com/current/path/#!/activities
```
